### PR TITLE
    LBM1-3153: Memtier threads core affinity

### DIFF
--- a/config_types.h
+++ b/config_types.h
@@ -27,6 +27,7 @@
 
 #include <vector>
 #include <string>
+#include <set>
 
 struct config_range {
     int min;
@@ -91,6 +92,49 @@ protected:
     struct addrinfo *m_server_addr;
     struct addrinfo *m_used_addr;
     int m_last_error;
+};
+
+struct config_cpu_list {
+    std::set<unsigned int> cpu_list;
+    std::set<unsigned int>::iterator next_cpu;
+
+    config_cpu_list() {}
+    explicit config_cpu_list(unsigned int cores);
+    explicit config_cpu_list(std::string str);
+    config_cpu_list(const config_cpu_list& copy);
+    config_cpu_list& operator=(const config_cpu_list& cl);
+
+    bool is_defined() const;
+    std::set<unsigned int> get_next_cpu();
+    std::set<unsigned int> get_cpu_list() const;
+    const char *print(char* buf, unsigned int size) const;
+
+    struct illegal_list_format {};
+    struct bad_cpu {
+        int cpu;
+
+        explicit bad_cpu(int cpu) : cpu(cpu) {}
+    };
+
+    struct illegal_range {
+        unsigned int begin;
+        unsigned int end;
+
+        explicit illegal_range(unsigned int begin, unsigned int end) : begin(begin), end(end) {}
+    };
+
+    struct duplicate_cpu {
+        int cpu;
+
+        explicit duplicate_cpu(int cpu) : cpu(cpu) {}
+    };
+
+private:
+    std::vector<std::string> parse_str(std::string str, char delimeter) const;
+    unsigned int parse_cpu(std::string str) const;
+    void add_cpu(unsigned int cpu);
+    void add_cpu_range(unsigned int cpu1, unsigned int cpu2);
+    void check_list_is_legal() const;
 };
 
 #endif /* _CONFIG_TYPES_H */

--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -221,6 +221,8 @@ static void config_init_defaults(struct benchmark_config *cfg)
         cfg->clients = 50;
     if (!cfg->threads)
         cfg->threads = 4;
+    if (!cfg->taskset.is_defined() && cfg->cpu_split)
+        cfg->taskset = config_cpu_list(get_nprocs());
     if (!cfg->ratio.is_defined())
         cfg->ratio = config_ratio("1:10");
     if (!cfg->pipeline)

--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -74,7 +74,8 @@ void benchmark_log(int level, const char *fmt, ...)
 
 static void config_print(FILE *file, struct benchmark_config *cfg)
 {
-    char tmpbuf[512];
+    char taskset_buf[512];
+    char size_list_buf[512];
     
     fprintf(file,
         "server = %s\n"
@@ -88,6 +89,8 @@ static void config_print(FILE *file, struct benchmark_config *cfg)
         "requests = %u\n"
         "clients = %u\n"
         "threads = %u\n"
+        "cpu_split = %s\n"
+        "taskset = %s\n"
         "test_time = %u\n"
         "ratio = %u:%u\n"
         "pipeline = %u\n"
@@ -128,6 +131,8 @@ static void config_print(FILE *file, struct benchmark_config *cfg)
         cfg->requests,
         cfg->clients,
         cfg->threads,
+        cfg->cpu_split ? "yes" : "no",
+        cfg->taskset.print(taskset_buf, sizeof(taskset_buf)-1),
         cfg->test_time,
         cfg->ratio.a, cfg->ratio.b,
         cfg->pipeline,
@@ -135,7 +140,7 @@ static void config_print(FILE *file, struct benchmark_config *cfg)
         cfg->data_offset,
         cfg->random_data ? "yes" : "no",
         cfg->data_size_range.min, cfg->data_size_range.max,
-        cfg->data_size_list.print(tmpbuf, sizeof(tmpbuf)-1),
+        cfg->data_size_list.print(size_list_buf, sizeof(size_list_buf)-1),
         cfg->data_size_pattern,
         cfg->expiry_range.min, cfg->expiry_range.max,
         cfg->data_import,
@@ -176,6 +181,8 @@ static void config_print_to_json(json_handler * jsonhandler, struct benchmark_co
     jsonhandler->write_obj("requests"          ,"%u",          	cfg->requests);
     jsonhandler->write_obj("clients"           ,"%u",          	cfg->clients);
     jsonhandler->write_obj("threads"           ,"%u",          	cfg->threads);
+    jsonhandler->write_obj("cpu_split"         ,"\"%s\"",              cfg->cpu_split ? "true" : "false");
+    jsonhandler->write_obj("taskset"           ,"\"%s\"",              cfg->taskset.print(tmpbuf, sizeof(tmpbuf)-1));
     jsonhandler->write_obj("test_time"         ,"%u",          	cfg->test_time);
     jsonhandler->write_obj("ratio"             ,"\"%u:%u\"",   	cfg->ratio.a, cfg->ratio.b);
     jsonhandler->write_obj("pipeline"          ,"%u",          	cfg->pipeline);

--- a/memtier_benchmark.h
+++ b/memtier_benchmark.h
@@ -49,6 +49,8 @@ struct benchmark_config {
     unsigned int requests;
     unsigned int clients;
     unsigned int threads;
+    bool cpu_split;
+    config_cpu_list taskset;
     unsigned int test_time;
     config_ratio ratio;
     unsigned int pipeline;


### PR DESCRIPTION
This request adds thread core affinity functionality to the memtier benchmark tool.
It will allow us to generate benchmark which will have threads running each on a dedicated core.
Two parameters were added to memtier:
    - split: run each threads on a dedicated core
    - taskset: list of cores to run threads on

issue: LBM1-3153