### PR TITLE
avoid memtier setting keys outside of specified range

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -143,9 +143,9 @@ bool client::setup_client(benchmark_config *config, abstract_protocol *protocol,
         m_obj_gen->set_random_seed(config->next_client_idx);
 
     if (config->key_pattern[0]=='P') {
-        int range = (config->key_maximum - config->key_minimum)/(config->clients*config->threads) + 1;
-        int min = config->key_minimum + range*config->next_client_idx;
-        int max = min+range;
+        unsigned long long range = (config->key_maximum - config->key_minimum)/(config->clients*config->threads) + 1;
+        unsigned long long min = config->key_minimum + range*config->next_client_idx;
+        unsigned long long max = min+range;
         if(config->next_client_idx==(int)(config->clients*config->threads)-1)
             max = config->key_maximum; //the last clients takes the leftover
         m_obj_gen->set_key_range(min, max);


### PR DESCRIPTION
In case of parallel workload (P:P) there was a casting to int, which incorrectly
lead for castring of "min,max" range of keys.
This lead to that benchmark using key-maximum and key-minumum outside of uint32 range
resulted in incorrec range been send.
for exampple specifying :
--key-maximum=4160114688 and --key-minimum=4160114688 reasulted in the following key to be sent: memtier-18446744073574699008
which is outside the range

command to reproduce the issue:
memtier_benchmark --debug --clients=1  --threads=1 --requests=allkeys --key-maximum=4160114688 --server=X.X.X.X --key-pattern=P:P --ratio=1:0 --key-minimum=4160114688 --data-size=1024