### PR TITLE
LBM1-3458: Allow generating compressible data

### DIFF
--- a/memtier_benchmark.cpp
+++ b/memtier_benchmark.cpp
@@ -1174,6 +1174,7 @@ int main(int argc, char *argv[])
             usage();
         }
         obj_gen->set_random_data(cfg.random_data);
+        obj_gen->set_compression_ratio(cfg.compression_ratio);
     }
 
     if (cfg.select_db > 0 && strcmp(cfg.protocol, "redis")) {

--- a/memtier_benchmark.h
+++ b/memtier_benchmark.h
@@ -57,6 +57,7 @@ struct benchmark_config {
     unsigned int data_size;
     unsigned int data_offset;
     bool random_data;
+    float compression_ratio;
     struct config_range data_size_range;
     config_weight_list data_size_list;
     const char *data_size_pattern;

--- a/obj_gen.cpp
+++ b/obj_gen.cpp
@@ -299,33 +299,10 @@ void object_generator::alloc_value_buffer(void)
                 assert(m_random_fd != -1);
             }
 
-            char buf1[64];
-            char buf2[64];
-            int buf1_idx = sizeof(buf1);
-            int buf2_idx = sizeof(buf2);
-            char *d = m_value_buffer;
             int ret;
-            int iter = 0;
-            
-            while (d - m_value_buffer < size) {
-                if (buf1_idx == sizeof(buf1)) {
-                    buf1_idx = 0;
-                    buf2_idx++;                    
-                    if (buf2_idx == sizeof(buf2)) {
-                        iter++;
-                        if (iter == 20) {                        
-                            ret = read(m_random_fd, buf1, sizeof(buf1));
-                            assert(ret > -1);
-                            ret = read(m_random_fd, buf2, sizeof(buf2));
-                            assert(ret > -1);
-                            buf1_idx = buf2_idx = iter = 0;
-                        }
-                    }
-                }
-                *d = buf1[buf1_idx] ^ buf2[buf2_idx] ^ iter;
-                d++;
-                buf1_idx++;
-            }
+
+            ret = read(m_random_fd, m_value_buffer, size);
+            assert(ret == (int)size);
         }
     }
 }

--- a/obj_gen.h
+++ b/obj_gen.h
@@ -100,6 +100,7 @@ protected:
     } m_data_size;
     const char *m_data_size_pattern;
     bool m_random_data;
+    float m_compression_ratio;
     unsigned int m_expiry_min;
     unsigned int m_expiry_max;
     const char *m_key_prefix;
@@ -117,6 +118,7 @@ protected:
     int m_random_fd;
     gaussian_noise m_random;
     unsigned int m_value_buffer_size;
+    unsigned int m_value_buffer_random_part_size;
     unsigned int m_value_buffer_mutation_pos;
     
     virtual void alloc_value_buffer(void);
@@ -133,6 +135,7 @@ public:
     unsigned long long normal_distribution(unsigned long long r_min, unsigned long long r_max, double r_stddev, double r_median);
 
     void set_random_data(bool random_data);
+    void set_compression_ratio(float compression_ratio);
     void set_data_size_fixed(unsigned int size);
     void set_data_size_range(unsigned int size_min, unsigned int size_max);
     void set_data_size_list(config_weight_list* data_size_list);


### PR DESCRIPTION
This PR add support in generating compressible data according to a desired ratio.
Before these changes memtier supported only "random" data or constant data.

@tomerr-lb this is a replacement to your solution which I find more simple.