### PR TITLE
LBM1-3330: invalid response status

### DIFF
--- a/protocol.cpp
+++ b/protocol.cpp
@@ -786,7 +786,8 @@ int memcache_binary_protocol::parse_response(void)
                 }
 
                 status = ntohs(m_response_hdr.message.header.response.status);
-                if (status == PROTOCOL_BINARY_RESPONSE_AUTH_ERROR ||
+                if (status == PROTOCOL_BINARY_RESPONSE_EINVAL ||
+                    status == PROTOCOL_BINARY_RESPONSE_AUTH_ERROR ||
                     status == PROTOCOL_BINARY_RESPONSE_AUTH_CONTINUE ||
                     status == PROTOCOL_BINARY_RESPONSE_NOT_SUPPORTED ||
                     status == PROTOCOL_BINARY_RESPONSE_UNKNOWN_COMMAND ||


### PR DESCRIPTION
Memtier didn't have handling of PROTOCOL_BINARY_RESPONSE_EINVAL
status in the parsing_response function, thus it was not logging
an error for that status.
Related PR's: https://github.com/LightBitsLabs/usrlight/pull/489

Issue: LBM1-3330