### PR TITLE
Tomer/add key to crc

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -1009,6 +1009,10 @@ void crc_verify_client::handle_response(struct timeval timestamp, request *reque
             bool get_key_req = true;
             const char *key = NULL;
             const char *rvalue = response->get_value(&rvalue_len, &key, &key_len);
+            if (values_count == 1 && key == NULL) {
+                key = vr->m_keylist.get_key(0, &key_len);
+                get_key_req = false;
+            }
             uint32_t crc = crc32::calc_crc32(rvalue, rvalue_len - crc32::size, key, key_len);
             const char *crc_buffer = rvalue + dynamic_cast<crc_object_generator *>(m_obj_gen)->get_actual_value_size();
             if (memcmp(crc_buffer, &crc, crc32::size) == 0) {
@@ -1019,7 +1023,7 @@ void crc_verify_client::handle_response(struct timeval timestamp, request *reque
                                     crc, *(uint32_t *) crc_buffer);
                 m_errors++;
             }
-            if (key != NULL)
+            if (key != NULL && get_key_req)
                 free((void*)key);
             if (rvalue != NULL)
                 free((void*)rvalue);

--- a/client.cpp
+++ b/client.cpp
@@ -852,8 +852,9 @@ void verify_client::create_request(struct timeval timestamp)
 void verify_client::handle_response(struct timeval timestamp, request *request, protocol_response *response)
 {
     unsigned int rvalue_len;
+    unsigned int key_len;
     const char* key = NULL;
-    const char *rvalue = response->get_value(&rvalue_len, key);
+    const char *rvalue = response->get_value(&rvalue_len, &key, &key_len);
     verify_request *vr = static_cast<verify_request *>(request);
 
     assert(vr->m_type == rt_get);
@@ -1004,9 +1005,11 @@ void crc_verify_client::handle_response(struct timeval timestamp, request *reque
         unsigned int values_count = response->get_values_count();
         for (unsigned int i = 0; i < values_count; i++) {
             unsigned int rvalue_len;
-            const char* key = NULL;
-            const char *rvalue = response->get_value(&rvalue_len, key);
-            uint32_t crc = crc32::calc_crc32(rvalue, rvalue_len - crc32::size);
+            unsigned int key_len;
+            bool get_key_req = true;
+            const char *key = NULL;
+            const char *rvalue = response->get_value(&rvalue_len, &key, &key_len);
+            uint32_t crc = crc32::calc_crc32(rvalue, rvalue_len - crc32::size, key, key_len);
             const char *crc_buffer = rvalue + dynamic_cast<crc_object_generator *>(m_obj_gen)->get_actual_value_size();
             if (memcmp(crc_buffer, &crc, crc32::size) == 0) {
                 benchmark_debug_log("key verified successfuly.\n");

--- a/obj_gen.cpp
+++ b/obj_gen.cpp
@@ -134,13 +134,16 @@ unsigned long long gaussian_noise::gaussian_distribution_range(double stddev, do
     return val;
 }
 
-uint32_t crc32::calc_crc32(const void *buffer, unsigned long length)
+uint32_t crc32::calc_crc32(const void *buffer, unsigned long length, const void *key, unsigned int key_length)
 {
     const unsigned char *cp = (const unsigned char *) buffer;
+    const unsigned char *kp = (const unsigned char *) key;
     uint32_t crc = 0;
 
     while (length--)
         crc = (crc << 8) ^ crctab[((crc >> 24) ^ *(cp++)) & 0xFF];
+    while (key_length--)
+        crc = (crc << 8) ^ crctab[((crc >> 24) ^ *(kp++)) & 0xFF];
 
     return crc;
 }
@@ -758,7 +761,8 @@ void crc_object_generator::alloc_value_buffer(const char* copy_from)
 data_object* crc_object_generator::get_object(int iter)
 {
     // compute key
-    get_key(iter, NULL);
+    unsigned int key_len;
+    const char* key = get_key(iter, &key_len);
 
     // compute size
     unsigned int new_size = 0;
@@ -782,7 +786,7 @@ data_object* crc_object_generator::get_object(int iter)
     }
 
     //calc and set crc
-    uint32_t crc = crc32::calc_crc32(m_value_buffer, m_actual_value_size);
+    uint32_t crc = crc32::calc_crc32(m_value_buffer, m_actual_value_size, key, key_len);
     memcpy(m_crc_buffer, &crc, m_crc_size);
 
     // set object

--- a/obj_gen.h
+++ b/obj_gen.h
@@ -74,7 +74,7 @@ public:
 class crc32 {
 public:
     static const unsigned int size = 4;
-    static uint32_t calc_crc32(const void *buffer, unsigned long length);
+    static uint32_t calc_crc32(const void *buffer, unsigned long length, const void *key, unsigned int key_length);
 private:
     static const unsigned int crctab[256];
 };

--- a/protocol.h
+++ b/protocol.h
@@ -24,9 +24,10 @@
 
 class key_val_node {
 public:
-    key_val_node(const char* value, unsigned int value_len, const char* key) :
-                 key(key), value(value), value_len(value_len) {};
+    key_val_node(const char* value, unsigned int value_len, const char* key, unsigned int key_len) :
+                 key(key), key_len(key_len), value(value), value_len(value_len) {};
     const char* key;
+    unsigned int key_len;
     const char* value;
     unsigned int value_len;
 };
@@ -52,8 +53,8 @@ public:
      void set_error(bool error);
      bool is_error(void);
 
-     void set_value(const char *value, unsigned int value_len , const char* key);
-     const char *get_value(unsigned int *value_len, const char* key);
+     void set_value(const char *value, unsigned int value_len , const char* key, unsigned int key_len);
+     const char *get_value(unsigned int *value_len, const char** key, unsigned int *key_len);
 
      void set_latency(unsigned int latency);
      unsigned int get_latency();


### PR DESCRIPTION
currently in data verify test we only test for data integrity, i.e. we hash the value and add this hash to the value itself, this way we can verify that data is in tact as we hash the data on response and check via hash. 
However we don't verify that this data is the correct response to the key, as key is not part of hash or data. 
we chose to  implement by adding the requested key to the CRC hash (hash data with key)
