### PR TITLE
Client: handle timeout race when updating event after writing to socket

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -423,7 +423,10 @@ void client::handle_event(short evtype)
         new_evtype = EV_READ;
     }
     if (evbuffer_get_length(m_write_buf) > 0) {
-        assert(finished() == false);
+        if (finished()) {
+            assert(m_config->requests <= 0 && "finished to write all requests but write buffer is not empty");
+            return;
+        }
         new_evtype |= EV_WRITE;
     }
 


### PR DESCRIPTION
after writing from the write buffer to socket or reading from socket we
update the event with read/write commands according to the test status.

if the write buffer still have more data in it we will scheduale write event,
right after checking the remaining write buffer length we used toassert if the test is finished.
this is wrong.

memtier tests can either be limited by timeout or by a requests number threshold not both,
in the case of requests number threshold if the test is finished and the write buffer
isnt empty an error occured and we should abort the test.
in the case of the test finished due to timeout reached even if the write buffer
is not empty we should just exit gracefully so stats wont be affected.

Issue: LBM1-4819